### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/api/Python/ChatGpt/__init__.py
+++ b/api/Python/ChatGpt/__init__.py
@@ -7,11 +7,12 @@ from langchain.embeddings.openai import OpenAIEmbeddings
 import os
 from langchain.vectorstores import Pinecone
 import pinecone
+import litellm
 from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.docstore.document import Document
 from Utilities.redisIndex import performRedisSearch
 from Utilities.cogSearch import performCogSearch
-from langchain.chat_models import AzureChatOpenAI, ChatOpenAI
+from langchain.chat_models import AzureChatOpenAI, ChatOpenAI, ChatLiteLLM
 from langchain.chains import RetrievalQAWithSourcesChain
 from langchain.prompts import PromptTemplate
 from Utilities.envVars import *
@@ -250,17 +251,30 @@ def GetRrrAnswer(history, approach, overrides, indexNs, indexType):
         openai.api_base = "https://api.openai.com/v1"
         openai.api_version = '2020-11-07' 
         openai.api_key = OpenAiApiKey
-        llmChat = ChatOpenAI(temperature=temperature,
+        llmChat = ChatLiteLLM(temperature=temperature,
                 openai_api_key=OpenAiApiKey,
                 max_tokens=tokenLength)
         embeddings = OpenAIEmbeddings(openai_api_key=OpenAiApiKey)
-        completion = openai.ChatCompletion.create(
+        completion = litellm.completion(
                 deployment_id=OpenAiChat,
                 model=gptModel,
                 messages=messages, 
                 temperature=0.0, 
                 max_tokens=32, 
                 n=1)
+    # Example usage of ChatLiteLLM
+    # elif embeddingModelType == "claude":
+    #     llmChat = ChatLiteLLM(model="claude-2"
+    #             temperature=temperature,
+    #             openai_api_key=OpenAiApiKey,
+    #             max_tokens=tokenLength)
+    #     completion = litellm.completion(
+    #             deployment_id=OpenAiChat,
+    #             model="claude-2",
+    #             messages=messages, 
+    #             temperature=0.0, 
+    #             max_tokens=32, 
+    #             n=1)
     
     try:
         # userToken = completion.usage.total_tokens

--- a/api/Python/requirements.txt
+++ b/api/Python/requirements.txt
@@ -108,3 +108,4 @@ wrapt==1.14.1
 XlsxWriter==3.0.9
 yarl==1.8.2
 zipp==3.15.0
+litellm0==0.1.400


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the OpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```

Here's an example of how just using `litellm.completion` works 
```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
